### PR TITLE
Substitute publisher with distributor, if unavailable

### DIFF
--- a/beetsplug/VGMplug.py
+++ b/beetsplug/VGMplug.py
@@ -288,6 +288,10 @@ class VGMdbPlugin(BeetsPlugin):
             day = None
 
         # label
+        if not "publisher" in albuminfo: # example: https://vgmdb.net/album/36099
+            albuminfo["publisher"] = { "link": {}, "names": {}, "role": {} }
+            if "distributor" in albuminfo:
+                albuminfo["publisher"] = albuminfo["distributor"]
         publisher = (
             list(albuminfo["publisher"]["names"].values())[0]
             if len(albuminfo["publisher"]["names"]) > 0


### PR DESCRIPTION
Sometimes a `publisher` is not specified (example: https://vgmdb.net/album/36099) which causes a crash at
```python
if len(albuminfo["publisher"]["names"]) > 0
```
This PR adds a fallback to a dummy publisher and substitutes with a distributor, if found. I think it makes sense, given their keys are identical.